### PR TITLE
fix(body decorator): correctly access message from rpc data

### DIFF
--- a/lib/decorators/google-pubsub-message-body.decorator.ts
+++ b/lib/decorators/google-pubsub-message-body.decorator.ts
@@ -3,7 +3,7 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
 export const GooglePubSubMessageBody = createParamDecorator<string | undefined>(
     (key, ctx: ExecutionContext) => {
-        const message: Message = ctx.switchToRpc().getData();
+        const message: Message = ctx.switchToRpc().getData().data;
         const body = JSON.parse(message.data.toString());
         if (key != null) {
             return body[key];


### PR DESCRIPTION
Rpc carries the message in the `data` property, extract it from there before parsing