### PR TITLE
fix(transport strategy): use builtin method to handle returns from su…

### DIFF
--- a/lib/server/server-google-pubsub.ts
+++ b/lib/server/server-google-pubsub.ts
@@ -198,7 +198,9 @@ export class GooglePubSubTransport extends Server implements CustomTransportStra
             mergeMap((handler) => {
                 if (handler == null)
                     throw Error('Transport Error: Handler should never be nullish.');
-                return from(handler(packet, ctx)).pipe(mergeMap((i) => i));
+                return from(handler(packet, ctx)).pipe(
+                    mergeMap((i) => this.transformToObservable(i)),
+                );
             }),
             catchError((err) => {
                 return of(err);


### PR DESCRIPTION
…bscription handlers

Use the provided `this.transformToObservable()` method to handle the return from handlers