### PR TITLE
refactor(server): handle pattern metadata errors when initializing subscriptions

### DIFF
--- a/lib/errors/invalid-pattern-metadata.exception.ts
+++ b/lib/errors/invalid-pattern-metadata.exception.ts
@@ -1,0 +1,9 @@
+import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.exception';
+
+export class InvalidPatternMetadataException extends RuntimeException {
+    public pattern: string;
+    constructor(pattern: string) {
+        super(`The supplied pattern metadata is invalid: ${pattern}`);
+        this.pattern = pattern;
+    }
+}

--- a/lib/server/server-google-pubsub.spec.ts
+++ b/lib/server/server-google-pubsub.spec.ts
@@ -2,6 +2,7 @@
 import { PubSub, Subscription } from '@google-cloud/pubsub';
 import { of } from 'rxjs';
 import { ClientGooglePubSub } from '../client';
+import { InvalidPatternMetadataException } from '../errors/invalid-pattern-metadata.exception';
 import { GooglePubSubTransport } from './server-google-pubsub';
 
 jest.mock('../client/client-google-pubsub.ts');
@@ -51,6 +52,18 @@ describe('Google PubSub Server', () => {
             expect(subscriptionExistsMock).toHaveBeenCalled();
             // @ts-expect-error
             expect(server.subscriptions.keys()).toContain(pattern);
+        });
+
+        it('should throw an InvalidPatternMetadata exception when given invalid JSON', async () => {
+            expect(() => {
+                return getSubscriptionFromPattern("[ this sure ain't JSON }");
+            }).rejects.toBeInstanceOf(InvalidPatternMetadataException);
+        });
+
+        it('should throw an InvalidPatternMetadata exception when object does not contain a topic or subscription name', async () => {
+            expect(() => {
+                return getSubscriptionFromPattern(JSON.stringify({}));
+            }).rejects.toBeInstanceOf(InvalidPatternMetadataException);
         });
 
         it("should get a subscription from a pattern and attempt to create if it doesn't exist", async () => {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "dist"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "jest --verbose",
     "test:ci": "npm run test -- --runInBand  --coverage --ci",
     "test:debug": "npm run test -- --runInBand",
-    "test:e2e": "jest --config test/jest-e2e.ts",
+    "test:e2e": "npm run test -- --config test/jest-e2e.ts",
     "test:e2e:ci": "npm run test:e2e -- --runInBand  --ci",
     "test:e2e:debug": "npm run test:e2e -- --runInBand",
     "build": "tsc",


### PR DESCRIPTION
Add a new error class, `InvalidPatternMetadataException`, and throw it when pattern metadata is
either invalid JSON or doesn't contain the required propertiess

#24 