### PR TITLE
feat(client-proxy): add delete methods for topics and subscriptions

### DIFF
--- a/examples/client/create-subscription.ts
+++ b/examples/client/create-subscription.ts
@@ -1,0 +1,24 @@
+import { ClientGooglePubSub } from '../../';
+
+const topicName: string | undefined = process.argv[2];
+const subscriptionName: string | undefined = process.argv[3];
+
+function printHelp() {
+    console.log(`Usage: ${process.argv0} ${process.argv[1]} TOPIC_NAME SUBSCRIPTION_NAME`);
+}
+
+function createSubscription(topic: string, subscription: string) {
+    const client = new ClientGooglePubSub();
+
+    return client.createSubscription(subscription, topic).toPromise();
+}
+
+if (!topicName || !subscriptionName) {
+    printHelp();
+    process.exit(1);
+}
+
+createSubscription(topicName, subscriptionName)
+    .then(() => console.log(`Subscription created ${subscriptionName}`))
+    .catch((error) => console.log(`An error ocurred while creating subscription: ${error.message}`))
+    .finally(() => process.exit(0));

--- a/examples/client/create-topic.ts
+++ b/examples/client/create-topic.ts
@@ -1,0 +1,23 @@
+import { ClientGooglePubSub } from '../../';
+
+const topicName: string | undefined = process.argv[2];
+
+function printHelp() {
+    console.log(`Usage: ${process.argv0} ${process.argv[1]} TOPIC_NAME`);
+}
+
+function createTopic(topic: string) {
+    const client = new ClientGooglePubSub();
+
+    return client.createTopic(topic).toPromise();
+}
+
+if (!topicName) {
+    printHelp();
+    process.exit(1);
+}
+
+createTopic(topicName)
+    .then(() => console.log(`Topic created ${topicName}`))
+    .catch((error) => console.log(`An error ocurred while creating topic: ${error.message}`))
+    .finally(() => process.exit(0));

--- a/examples/client/delete-subscription.ts
+++ b/examples/client/delete-subscription.ts
@@ -1,0 +1,25 @@
+import { ClientGooglePubSub } from '../../';
+
+const subscriptionName: string | undefined = process.argv[2];
+
+function printHelp() {
+    console.log(`Usage: ${process.argv0} ${process.argv[1]} SUBSCRIPTION_NAME`);
+}
+
+function deleteSubscription(subscription: string) {
+    const client = new ClientGooglePubSub();
+
+    return client.deleteSubscription(subscription).toPromise();
+}
+
+if (!subscriptionName) {
+    printHelp();
+    process.exit(1);
+}
+
+deleteSubscription(subscriptionName)
+    .then(() => console.log(`Subscription ${subscriptionName} deleted!`))
+    .catch((error) =>
+        console.log(`An error ocurred while deleting ${subscriptionName}: ${error.message}`),
+    )
+    .finally(() => process.exit(0));

--- a/examples/client/delete-topic.ts
+++ b/examples/client/delete-topic.ts
@@ -1,0 +1,23 @@
+import { ClientGooglePubSub } from '../../';
+
+const topicName: string | undefined = process.argv[2];
+
+function printHelp() {
+    console.log(`Usage: ${process.argv0} ${process.argv[1]} TOPIC_NAME`);
+}
+
+function deleteTopic(topic: string) {
+    const client = new ClientGooglePubSub();
+
+    return client.deleteTopic(topic).toPromise();
+}
+
+if (!topicName) {
+    printHelp();
+    process.exit(1);
+}
+
+deleteTopic(topicName)
+    .then(() => console.log(`Topic ${topicName} deleted!`))
+    .catch((error) => console.log(`An error ocurred while deleting ${topicName}: ${error.message}`))
+    .finally(() => process.exit(0));

--- a/lib/client/client-google-pubsub.ts
+++ b/lib/client/client-google-pubsub.ts
@@ -8,7 +8,7 @@ import {
 import { Injectable } from '@nestjs/common';
 import { ClientProxy, ReadPacket, WritePacket } from '@nestjs/microservices';
 import { from, fromEvent, Observable, of, OperatorFunction, throwError } from 'rxjs';
-import { map, mergeMap } from 'rxjs/operators';
+import { map, mapTo, mergeMap } from 'rxjs/operators';
 import { GOOGLE_PUBSUB_SUBSCRIPTION_MESSAGE_EVENT } from '../constants';
 import {
     ClientHealthInfo,
@@ -113,6 +113,15 @@ export class ClientGooglePubSub extends ClientProxy {
     }
 
     /**
+     * Attempts to delete a Subscription instance
+     * @param subscription
+     * @returns
+     */
+    public deleteSubscription(subscription: string | GooglePubSubSubscription): Observable<void> {
+        return from(this.getSubscription(subscription).delete()).pipe(mapTo(void 0));
+    }
+
+    /**
      * Register a listener for from `message` events on the PubSub client for the
      * supplied subscription
      * @param subscription
@@ -161,6 +170,15 @@ export class ClientGooglePubSub extends ClientProxy {
     }
 
     /**
+     * Attempts to delete a Topic instance
+     * @param topic
+     * @returns
+     */
+    public deleteTopic(topic: string | GooglePubSubTopic): Observable<void> {
+        return from(this.getTopic(topic).delete()).pipe(mapTo(void 0));
+    }
+
+    /**
      * Returns client health information
      * @returns
      */
@@ -188,16 +206,6 @@ export class ClientGooglePubSub extends ClientProxy {
     private parseExistsResponse: OperatorFunction<ExistsResponse, boolean> = map(
         (existsResponse: ExistsResponse) => existsResponse[0],
     );
-
-    /**
-     * Indicates if the provided value is a string
-     * @param str
-     */
-    private isString(
-        str?: string | GooglePubSubTopic | GooglePubSubSubscription | null,
-    ): str is string {
-        return typeof str === 'string';
-    }
 
     /**
      * Indicates if the provided value is a Topic instance

--- a/test/__mocks__/@google-cloud/pubsub.ts
+++ b/test/__mocks__/@google-cloud/pubsub.ts
@@ -8,12 +8,6 @@ const { Topic, Subscription } = jest.requireActual('@google-cloud/pubsub');
 const moduleMock: any = jest.genMockFromModule('@google-cloud/pubsub');
 const PubSubMock: jest.MockedClass<typeof PubSub> = moduleMock.PubSub;
 
-Topic.prototype.createSubscription = jest
-    .fn()
-    .mockImplementation((name, options) =>
-        Promise.resolve([new Subscription(new PubSubMock(), name, options)]),
-    );
-
 PubSubMock.prototype.subscription.mockImplementation(
     (name, options): SubscriptionType => new Subscription(new PubSubMock(), name, options),
 );
@@ -22,17 +16,51 @@ PubSubMock.prototype.topic.mockImplementation((name, options) => {
     return new Topic(new PubSubMock(), name, options);
 });
 
+PubSubMock.prototype.close.mockImplementation(() => {
+    return Promise.resolve();
+});
+
 const subscriptionExistsMock = jest.fn().mockImplementation(() => {
     return Promise.resolve([true]);
 });
 
 Subscription.prototype.exists = subscriptionExistsMock;
 
+const subscriptionDeleteMock = jest.fn().mockImplementation(() => {
+    return Promise.resolve([true]);
+});
+
+Subscription.prototype.delete = subscriptionDeleteMock;
+
+const subscriptionCreateMock = jest
+    .fn()
+    .mockImplementation((name, options) =>
+        Promise.resolve([new Subscription(new PubSubMock(), name, options)]),
+    );
+Topic.prototype.createSubscription = subscriptionCreateMock;
+
+const topicCreateMock = jest
+    .fn()
+    .mockImplementation(() => Promise.resolve([new Topic(new PubSubMock(), 'mock-topic')]));
+Topic.prototype.create = topicCreateMock;
+
 const topicExistsMock = jest.fn().mockImplementation(() => {
     return Promise.resolve([true]);
 });
 
 Topic.prototype.exists = topicExistsMock;
+
+const topicDeleteMock = jest.fn().mockImplementation(() => {
+    return Promise.resolve([true]);
+});
+
+Topic.prototype.delete = topicDeleteMock;
+
+const topicPublishMock = jest.fn().mockImplementation(() => {
+    return Promise.resolve([true]);
+});
+
+Topic.prototype.publish = topicPublishMock;
 
 module.exports = {
     PubSub: PubSubMock,


### PR DESCRIPTION
Add two methods, one to delete topics and another to delete subcriptions. Also cleaned up client
tests to use the global pubsub mock.