### PR TITLE
feat(client-proxy): support Buffers and objects when publishing

### DIFF
--- a/lib/client/client-google-pubsub.spec.ts
+++ b/lib/client/client-google-pubsub.spec.ts
@@ -13,6 +13,9 @@ const clientProxy: ClientGooglePubSub = new ClientGooglePubSub({ pubSubClient: c
 
 const mockedClose = PubSub.prototype.close as jest.MockedFunction<PubSub['close']>;
 const mockedPublish = Topic.prototype.publish as jest.MockedFunction<GooglePubSubTopic['publish']>;
+const mockedPublishJSON = Topic.prototype.publishJSON as jest.MockedFunction<
+    GooglePubSubTopic['publishJSON']
+>;
 const mockedSubscriptionExists = Subscription.prototype.exists as jest.MockedFunction<
     Subscription['exists']
 >;
@@ -39,7 +42,22 @@ describe('ClientGooglePubSub', () => {
         it('should attempt to publish a Buffer to the provided topic', async () => {
             await clientProxy.publishToTopic(topicName, testBuffer).toPromise();
             expect(client.topic).toHaveBeenLastCalledWith(topicName);
-            expect(mockedPublish).toHaveBeenLastCalledWith(testBuffer);
+            expect(mockedPublish).toHaveBeenLastCalledWith(testBuffer, undefined);
+        });
+
+        it('should attempt to publish an object to the provided topic', async () => {
+            const data = { songTitle: "Comin' on" };
+            await clientProxy.publishToTopic(topicName, data).toPromise();
+            expect(client.topic).toHaveBeenLastCalledWith(topicName);
+            expect(mockedPublishJSON).toHaveBeenLastCalledWith(data, undefined);
+        });
+
+        it('should attempt to publish an object to the provided topic with message attributes', async () => {
+            const data = { songTitle: "Comin' on" };
+            const attrs = { bandName: 'The Shamen' };
+            await clientProxy.publishToTopic(topicName, data, attrs).toPromise();
+            expect(client.topic).toHaveBeenLastCalledWith(topicName);
+            expect(mockedPublishJSON).toHaveBeenLastCalledWith(data, attrs);
         });
     });
 

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -1,10 +1,20 @@
-import { ClientConfig, Message, PubSub, Subscription, Topic } from '@google-cloud/pubsub';
+import {
+    Attributes,
+    ClientConfig,
+    Message,
+    PubSub,
+    Subscription,
+    Topic,
+} from '@google-cloud/pubsub';
+import { ReadPacket } from '@nestjs/microservices';
 import { ClientGooglePubSub } from './client';
 import { GooglePubSubContext } from './ctx-host';
 
 export type GooglePubSubMessage = Message;
+export type GooglePubSubMessageAttributes = Attributes;
 export type GooglePubSubTopic = Topic;
 export type GooglePubSubSubscription = Subscription;
+
 export type AckFunction = () => void;
 export type NackFunction = () => void;
 export interface GooglePubSubSubscriptionPatternMetadata {
@@ -65,4 +75,15 @@ export interface ClientHealthInfo {
 export interface GooglePubSubOptions {
     pubSubClient?: PubSub;
     pubSubClientConfig?: ClientConfig;
+}
+
+export type PublishData = Buffer | Record<string, any>;
+
+export interface ClientGooglePubSubOutgoingRequestData {
+    message: PublishData;
+    attributes?: GooglePubSubMessageAttributes;
+}
+
+export interface ClientGooglePubSubOutgoingRequestSerializedData extends ReadPacket {
+    data: ClientGooglePubSubOutgoingRequestData;
 }

--- a/test/__mocks__/@google-cloud/pubsub.ts
+++ b/test/__mocks__/@google-cloud/pubsub.ts
@@ -23,13 +23,11 @@ PubSubMock.prototype.close.mockImplementation(() => {
 const subscriptionExistsMock = jest.fn().mockImplementation(() => {
     return Promise.resolve([true]);
 });
-
 Subscription.prototype.exists = subscriptionExistsMock;
 
 const subscriptionDeleteMock = jest.fn().mockImplementation(() => {
     return Promise.resolve([true]);
 });
-
 Subscription.prototype.delete = subscriptionDeleteMock;
 
 const subscriptionCreateMock = jest
@@ -47,20 +45,22 @@ Topic.prototype.create = topicCreateMock;
 const topicExistsMock = jest.fn().mockImplementation(() => {
     return Promise.resolve([true]);
 });
-
 Topic.prototype.exists = topicExistsMock;
 
 const topicDeleteMock = jest.fn().mockImplementation(() => {
     return Promise.resolve([true]);
 });
-
 Topic.prototype.delete = topicDeleteMock;
 
 const topicPublishMock = jest.fn().mockImplementation(() => {
     return Promise.resolve([true]);
 });
-
 Topic.prototype.publish = topicPublishMock;
+
+const topicPublishJSONMock = jest.fn().mockImplementation(() => {
+    return Promise.resolve([true]);
+});
+Topic.prototype.publishJSON = topicPublishJSONMock;
 
 module.exports = {
     PubSub: PubSubMock,


### PR DESCRIPTION
Support both Buffers and objects when publishing to a topic. Add support for message attributes when publishing.

re #3 