### PR TITLE
fix(server): prevent decorator arg ordering from preventing handler lookup

### DIFF
--- a/lib/server/server-google-pubsub.ts
+++ b/lib/server/server-google-pubsub.ts
@@ -1,5 +1,11 @@
 import { Logger } from '@nestjs/common';
-import { CustomTransportStrategy, ReadPacket, Server } from '@nestjs/microservices';
+import {
+    CustomTransportStrategy,
+    MessageHandler,
+    MsPattern,
+    ReadPacket,
+    Server,
+} from '@nestjs/microservices';
 import { from, merge, Observable, of, Subscription } from 'rxjs';
 import { catchError, map, mergeMap } from 'rxjs/operators';
 import { ClientGooglePubSub } from '../client';
@@ -254,5 +260,9 @@ export class GooglePubSubTransport extends Server implements CustomTransportStra
     public async close(): Promise<void> {
         this.listenerSubscription && this.listenerSubscription.unsubscribe();
         await this.googlePubSubClient.close();
+    }
+
+    public getHandlerByPattern(pattern: string): MessageHandler | null {
+        return this.messageHandlers.get(pattern) ?? null;
     }
 }

--- a/test/server/server.e2e-spec.ts
+++ b/test/server/server.e2e-spec.ts
@@ -63,6 +63,12 @@ describe('Server E2E Tests', () => {
             expect(subscriptions.size).toBe(3);
         });
 
+        it('should be able to get handlers for all subscriptions', () => {
+            for (const [pattern] of subscriptions) {
+                expect(strategy.getHandlerByPattern(pattern)).not.toBeNull();
+            }
+        });
+
         it('it should initialize a subscription when a topic name and subscription name are provided', () => {
             const subscription: Subscription = subscriptions.get(
                 JSON.stringify(expendablesHandlerPattern),


### PR DESCRIPTION
When passing args through the message handler decorator, the
microservice server's default implementation for looking up handlers
involved a step where the keys of an object would be sorted, which
resulted in the possibility of different sorting orders. We've
overridden the method that does this sorting, which simplifies all of
the logic in general.