### PR TITLE
build(gcb): remove failing doc deploy step

### DIFF
--- a/deploy/deploy-package.yaml
+++ b/deploy/deploy-package.yaml
@@ -26,7 +26,3 @@ steps:
     - 'NPM_TOKEN=$_NPM_TOKEN'
     - 'GH_TOKEN=$_GH_TOKEN'
   args: ['run', 'semantic-release', '--', '-d', 'false', '--no-ci']
-- name: node
-  id: "npm run docs:deploy"
-  entrypoint: npm
-  args: ['run', 'docs:deploy']


### PR DESCRIPTION
The doc deploy step is failing because Cloudbuild creates some kind of hacky broken version of the repo to do its work. `gh-pages` can't interact with the remote properly.