### PR TITLE
docs: deploy docs using post-push hook

### DIFF
--- a/.husky/post-push
+++ b/.husky/post-push
@@ -1,0 +1,11 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+CURRENT_BRANCH=$(git branch --show-current)
+
+if [ $CURRENT_BRANCH = master ];
+then
+  npm run docs:deploy;
+fi
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "example:server": "node --inspect -r ts-node/register examples/server/main.ts",
     "docs:build": "typedoc",
     "docs:watch": "typedoc --watch",
-    "docs:deploy": "npm run docs:build && gh-pages -d docs -u 'Harold Waters <harold.waters@flosports.tv>'",
+    "docs:deploy": "npm run docs:build && gh-pages -d docs",
     "prepare": "husky install && npm run build",
     "lint": "eslint . --ext .js,.ts",
     "lint:fix": "eslint --fix-dry-run . --ext .js,.ts",


### PR DESCRIPTION
The post-push hook will only run after successfully pushing, and the script will only deploy the docs if the current branch is master. Harold's user is also removed from the options for `gh-pages`. It's not because I don't like him, but because it's not necessary when pushing from local.

resolves #48