### PR TITLE
fix(server): use existing subscription if it already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,22 +69,26 @@ attempt to create a new subscription if the requested subscription for a handler
 not already present.The microservice takes a `subscriptionNamingStrategy` as an
 argument, which expects a class conforming to the `SubscriptionNamingStrategy`
 interface. A basic strategy is included by default:
+
 ```typescript
 import {
-    SubscriptionNamingStrategy
+  SubscriptionNamingStrategy
 } from '@flosports/nestjs-google-pubsub-microservice';
+import { SubscriptionNameDependencies } from './interfaces';
 
 export class BasicSubscriptionNamingStrategy
-    implements SubscriptionNamingStrategy {
-    public generateSubscriptionName(
-        topicName: string,
-        subscriptionName?: string
-    ): string {
-        if (subscriptionName) {
-            return subscriptionName;
-        }
-        return `${topicName}-sub`
+        implements SubscriptionNamingStrategy {
+  public generateSubscriptionName(
+      deps: SubscriptionNameDependencies
+  ): string {
+    switch (deps._tag) {
+      case 'TopicAndSubscriptionNames':
+      case 'SubscriptionNameOnly':
+        return deps.subscriptionName;
+      case 'TopicNameOnly':
+        return `${deps.topicName}-sub`;
     }
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,18 +74,18 @@ interface. A basic strategy is included by default:
 import {
   SubscriptionNamingStrategy
 } from '@flosports/nestjs-google-pubsub-microservice';
-import { SubscriptionNameDependencies } from './interfaces';
+import { NamingDependencyTag, SubscriptionNameDependencies } from './interfaces';
 
 export class BasicSubscriptionNamingStrategy
         implements SubscriptionNamingStrategy {
   public generateSubscriptionName(
-      deps: SubscriptionNameDependencies
+          deps: SubscriptionNameDependencies
   ): string {
     switch (deps._tag) {
-      case 'TopicAndSubscriptionNames':
-      case 'SubscriptionNameOnly':
+      case NamingDependencyTag.TOPIC_AND_SUBSCRIPTION_NAMES:
+      case NamingDependencyTag.SUBSCRIPTION_NAME_ONLY:
         return deps.subscriptionName;
-      case 'TopicNameOnly':
+      case NamingDependencyTag.TOPIC_NAME_ONLY:
         return `${deps.topicName}-sub`;
     }
   }

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -41,18 +41,24 @@ export interface GooglePubSubTransportOptions {
     nackStrategy?: NackStrategy;
 }
 
+export enum NamingDependencyTag {
+    TOPIC_NAME_ONLY = 'TopicNameOnly',
+    SUBSCRIPTION_NAME_ONLY = 'SubscriptionNameOnly',
+    TOPIC_AND_SUBSCRIPTION_NAMES = 'TopicAndSubscriptionNames',
+}
+
 export interface TopicNameOnly {
-    _tag: 'TopicNameOnly';
+    _tag: NamingDependencyTag.TOPIC_NAME_ONLY;
     topicName: string;
 }
 
 export interface SubscriptionNameOnly {
-    _tag: 'SubscriptionNameOnly';
+    _tag: NamingDependencyTag.SUBSCRIPTION_NAME_ONLY;
     subscriptionName: string;
 }
 
 export interface TopicAndSubscriptionNames {
-    _tag: 'TopicAndSubscriptionNames';
+    _tag: NamingDependencyTag.TOPIC_AND_SUBSCRIPTION_NAMES;
     topicName: string;
     subscriptionName: string;
 }

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -41,7 +41,38 @@ export interface GooglePubSubTransportOptions {
     nackStrategy?: NackStrategy;
 }
 
-export type GenerateSubscriptionName = (topicName: string, subscriptionName?: string) => string;
+export interface TopicNameOnly {
+    _tag: 'TopicNameOnly';
+    topicName: string;
+}
+
+export interface SubscriptionNameOnly {
+    _tag: 'SubscriptionNameOnly';
+    subscriptionName: string;
+}
+
+export interface TopicAndSubscriptionNames {
+    _tag: 'TopicAndSubscriptionNames';
+    topicName: string;
+    subscriptionName: string;
+}
+
+/**
+ * The possible configurations for producing a subscription name.
+ *
+ * @remarks
+ * This allows the writer of a custom `SubscriptionNamingStrategy` to
+ * conveniently switch on the `_tag` member to enforce handling of all
+ * possible combinations of subscription and topic names.
+ *
+ * @see BasicSubscriptionNamingStrategy
+ */
+export type SubscriptionNameDependencies =
+    | TopicNameOnly
+    | SubscriptionNameOnly
+    | TopicAndSubscriptionNames;
+
+export type GenerateSubscriptionName = (deps: SubscriptionNameDependencies) => string;
 export interface SubscriptionNamingStrategy {
     generateSubscriptionName: GenerateSubscriptionName;
 }

--- a/lib/server/server-google-pubsub.spec.ts
+++ b/lib/server/server-google-pubsub.spec.ts
@@ -90,8 +90,20 @@ describe('Google PubSub Server', () => {
             expect(server.subscriptions.keys()).toContain(pattern);
         });
 
-        it.todo(
-            'should get a subscription from a pattern and not attempt to create if createSubscription is set to false',
-        );
+        it('should get a subscription from a pattern and not attempt to create if createSubscription is set to false', async () => {
+            // @ts-expect-error
+            server.createSubscriptions = true;
+            const pattern = JSON.stringify({
+                subscriptionName: 'my-sub-name',
+                topicName: 'my-topic-name',
+            });
+            subscriptionExistsMock.mockImplementationOnce(() => of(true));
+            await getSubscriptionFromPattern(pattern);
+
+            expect(subscriptionExistsMock).toHaveBeenCalled();
+            expect(createSubscriptionMock).not.toHaveBeenCalled();
+            // @ts-expect-error
+            expect(server.subscriptions.keys()).toContain(pattern);
+        });
     });
 });

--- a/lib/server/server-google-pubsub.ts
+++ b/lib/server/server-google-pubsub.ts
@@ -1,11 +1,5 @@
 import { Logger } from '@nestjs/common';
-import {
-    CustomTransportStrategy,
-    MessageHandler,
-    MsPattern,
-    ReadPacket,
-    Server,
-} from '@nestjs/microservices';
+import { CustomTransportStrategy, MessageHandler, ReadPacket, Server } from '@nestjs/microservices';
 import { from, merge, Observable, of, Subscription } from 'rxjs';
 import { catchError, map, mapTo, mergeMap } from 'rxjs/operators';
 import { ClientGooglePubSub } from '../client';
@@ -14,15 +8,14 @@ import { GooglePubSubMessageDeserializer } from '../deserializers';
 import { InvalidPatternMetadataException } from '../errors';
 import { TransportError } from '../errors/transport-error.exception';
 import {
-    AckFunction,
     AckStrategy,
     GooglePubSubMessage,
     GooglePubSubPatternMetadata,
     GooglePubSubSubscription,
     GooglePubSubTopic,
     GooglePubSubTransportOptions,
-    NackFunction,
     NackStrategy,
+    NamingDependencyTag,
     SubscriptionNameDependencies,
     SubscriptionNamingStrategy,
     TopicNamingStrategy,
@@ -201,7 +194,7 @@ export class GooglePubSubTransport extends Server implements CustomTransportStra
 
         if (topicName && subscriptionName) {
             return {
-                _tag: 'TopicAndSubscriptionNames',
+                _tag: NamingDependencyTag.TOPIC_AND_SUBSCRIPTION_NAMES,
                 topicName,
                 subscriptionName,
             };
@@ -209,14 +202,14 @@ export class GooglePubSubTransport extends Server implements CustomTransportStra
 
         if (topicName) {
             return {
-                _tag: 'TopicNameOnly',
+                _tag: NamingDependencyTag.TOPIC_NAME_ONLY,
                 topicName,
             };
         }
 
         if (subscriptionName) {
             return {
-                _tag: 'SubscriptionNameOnly',
+                _tag: NamingDependencyTag.SUBSCRIPTION_NAME_ONLY,
                 subscriptionName,
             };
         }

--- a/lib/strategies/basic-subscription-naming-strategy.spec.ts
+++ b/lib/strategies/basic-subscription-naming-strategy.spec.ts
@@ -6,12 +6,19 @@ const subscriptionName = 'totally-rocks';
 describe('Basic Naming Strategy', () => {
     const strategy = new BasicSubscriptionNamingStrategy();
     it('should return a subscription name if one is supplied', () => {
-        const name = strategy.generateSubscriptionName(topicName, subscriptionName);
+        const name = strategy.generateSubscriptionName({
+            _tag: 'TopicAndSubscriptionNames',
+            topicName,
+            subscriptionName,
+        });
 
         expect(name).toEqual(`${subscriptionName}`);
     });
     it(`should return ${topicName}-sub if no subscription name is provided`, () => {
-        const name = strategy.generateSubscriptionName(topicName);
+        const name = strategy.generateSubscriptionName({
+            _tag: 'TopicNameOnly',
+            topicName,
+        });
 
         expect(name).toEqual(`${topicName}-sub`);
     });

--- a/lib/strategies/basic-subscription-naming-strategy.spec.ts
+++ b/lib/strategies/basic-subscription-naming-strategy.spec.ts
@@ -1,4 +1,5 @@
 import { BasicSubscriptionNamingStrategy } from './basic-subscription-naming-strategy';
+import { NamingDependencyTag } from '../interfaces';
 
 const topicName = 'expendables-1';
 const subscriptionName = 'totally-rocks';
@@ -7,7 +8,7 @@ describe('Basic Naming Strategy', () => {
     const strategy = new BasicSubscriptionNamingStrategy();
     it('should return a subscription name if one is supplied', () => {
         const name = strategy.generateSubscriptionName({
-            _tag: 'TopicAndSubscriptionNames',
+            _tag: NamingDependencyTag.TOPIC_AND_SUBSCRIPTION_NAMES,
             topicName,
             subscriptionName,
         });
@@ -16,7 +17,7 @@ describe('Basic Naming Strategy', () => {
     });
     it(`should return ${topicName}-sub if no subscription name is provided`, () => {
         const name = strategy.generateSubscriptionName({
-            _tag: 'TopicNameOnly',
+            _tag: NamingDependencyTag.TOPIC_NAME_ONLY,
             topicName,
         });
 

--- a/lib/strategies/basic-subscription-naming-strategy.ts
+++ b/lib/strategies/basic-subscription-naming-strategy.ts
@@ -1,10 +1,25 @@
-import { SubscriptionNamingStrategy } from '../interfaces';
+import { SubscriptionNameDependencies, SubscriptionNamingStrategy } from '../interfaces';
 
+/**
+ * The default strategy for creating subscription names.
+ *
+ * @remarks
+ * If the subscription name is provided, that name will be used directly.
+ * If only a topic name is provided, it will be used to generate a
+ * subscription name.
+ *
+ * This strategy only supports one subscription per topic. Implement
+ * a custom strategy if you need to have more than one subscription
+ * per topic.
+ */
 export class BasicSubscriptionNamingStrategy implements SubscriptionNamingStrategy {
-    public generateSubscriptionName(topicName: string, subscriptionName?: string): string {
-        if (subscriptionName) {
-            return subscriptionName;
+    public generateSubscriptionName(deps: SubscriptionNameDependencies): string {
+        switch (deps._tag) {
+            case 'TopicAndSubscriptionNames':
+            case 'SubscriptionNameOnly':
+                return deps.subscriptionName;
+            case 'TopicNameOnly':
+                return `${deps.topicName}-sub`;
         }
-        return `${topicName}-sub`;
     }
 }

--- a/lib/strategies/basic-subscription-naming-strategy.ts
+++ b/lib/strategies/basic-subscription-naming-strategy.ts
@@ -1,4 +1,8 @@
-import { SubscriptionNameDependencies, SubscriptionNamingStrategy } from '../interfaces';
+import {
+    NamingDependencyTag,
+    SubscriptionNameDependencies,
+    SubscriptionNamingStrategy,
+} from '../interfaces';
 
 /**
  * The default strategy for creating subscription names.
@@ -15,10 +19,10 @@ import { SubscriptionNameDependencies, SubscriptionNamingStrategy } from '../int
 export class BasicSubscriptionNamingStrategy implements SubscriptionNamingStrategy {
     public generateSubscriptionName(deps: SubscriptionNameDependencies): string {
         switch (deps._tag) {
-            case 'TopicAndSubscriptionNames':
-            case 'SubscriptionNameOnly':
+            case NamingDependencyTag.TOPIC_AND_SUBSCRIPTION_NAMES:
+            case NamingDependencyTag.SUBSCRIPTION_NAME_ONLY:
                 return deps.subscriptionName;
-            case 'TopicNameOnly':
+            case NamingDependencyTag.TOPIC_NAME_ONLY:
                 return `${deps.topicName}-sub`;
         }
     }


### PR DESCRIPTION
When subscription names aren't provided, and the name is
generated by a `SubscriptionNamingStrategy`, an error will occur if
the subscription already exists. In order to prevent duplication of
effort, I refactored the
`GooglePubSubTransport#getSubscriptionFromPattern` method to
delegate different concerns to other private methods. Later, these
methods could be extracted into separate classes to simplify testing.

resolves #42