### PR TITLE
fix(server): use topic naming strategy to create topic names

### DIFF
--- a/lib/server/server-google-pubsub.ts
+++ b/lib/server/server-google-pubsub.ts
@@ -245,11 +245,12 @@ export class GooglePubSubTransport extends Server implements CustomTransportStra
             throw new InvalidPatternMetadataException(pattern);
         }
 
-        const topic: GooglePubSubTopic | null = this.googlePubSubClient.getTopic(topicName);
+        const _topicName = this.topicNamingStrategy.generateTopicName(topicName);
+        const topic: GooglePubSubTopic | null = this.googlePubSubClient.getTopic(_topicName);
 
-        return this.createSubscriptions
-            ? await this.googlePubSubClient.createSubscription(subscriptionName, topic).toPromise()
-            : null;
+        return await this.googlePubSubClient
+            .createSubscription(subscriptionName, topic)
+            .toPromise();
     };
 
     /**


### PR DESCRIPTION
The topic naming strategy wasn't being used to process the topic name.